### PR TITLE
docs: replace `sdkActive` with `askPermissions`

### DIFF
--- a/documentation/using-the-sdk.md
+++ b/documentation/using-the-sdk.md
@@ -178,7 +178,7 @@ The app can now ask for permissions on appropriate moments. Note that the SDK ne
   
 // disable askPermissions, just before initializing the SDK
 InbeaconSdk.sharedInstance.askPermissions = false
-InbeaconSdk.createWith(clientId: "<your client-ID>",clientSecret:  "<your client-secret>")  
+InbeaconSdk.createWith(clientId: "<your client-ID>", clientSecret: "<your client-secret>")  
 ...
 
 // Later on, activate the SDK at any moment you like. 
@@ -195,12 +195,12 @@ UIApplication.shared.registerUserNotificationSettings(
 ```objc
 //Objective-C
 
-// Start SDK in de-activated mode, just before initializing the SDK
-InbeaconSdk.sharedInstance.sdkActive = false;
-InbeaconSdk.createWith(clientId: "<your client-ID>",clientSecret:  "<your client-secret>")
+// disable askPermissions, just before initializing the SDK
+InbeaconSdk.sharedInstance.askPermissions = false;
+InbeaconSdk.createWith(clientId: "<your client-ID>", clientSecret: "<your client-secret>")
 ...
 // Later on, activate the SDK at any moment you like
-InbeaconSdk.sharedInstance.sdkActive = true
+InbeaconSdk.sharedInstance.askPermissions = true
 
 // or ask for permissions yourself at an appropriate time
 [locationManager requestWhenInUseAuthorization];


### PR DESCRIPTION
`sdkActive` is a non-existing property, so I figure this was the working name in development.